### PR TITLE
Exclude internal packages from javadoc

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -360,6 +360,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
+                            <excludePackageNames>*.internal.*</excludePackageNames>
                             <!-- Never skip the javadoc attachment as secondary artifact -->
                             <skip>false</skip>
                         </configuration>


### PR DESCRIPTION
Optimize the build by excluding _.internal._ packages from the javadoc.
