### PR TITLE
FIX: Coveralls reporting merged report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.4.8 (????-??-??)
+
+* [chg] Fixes coveralls plugin reporting only Unit Test coverage. 
+
 # Version 3.4.7 (2019-12-12)
 
 * [chg] Upgrade spotbugs to 3.1.12

--- a/parent-internal/pom.xml
+++ b/parent-internal/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.poms</groupId>
         <artifactId>poms</artifactId>
-        <version>3.4.7-SNAPSHOT</version>
+        <version>3.4.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>parent-internal</artifactId>
@@ -174,6 +174,9 @@
                     <artifactId>coveralls-maven-plugin</artifactId>
                     <version>${coveralls-maven-plugin.version}</version>
                     <configuration>
+                        <jacocoReports>
+                            ${project.build.directory}/site/jacoco-all/jacoco.xml
+                        </jacocoReports>
                         <relativeReportDirs>
                             <relativeReportDir>jacoco-all</relativeReportDir>
                         </relativeReportDirs>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>org.seedstack.poms</groupId>
     <artifactId>poms</artifactId>
-    <version>3.4.7-SNAPSHOT</version>
+    <version>3.4.8-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Now Coveralls should prefeer jacoco-all instad of jacoco (UT)